### PR TITLE
fix paddr meaning

### DIFF
--- a/website/contents/ja/12-page-table.mdx
+++ b/website/contents/ja/12-page-table.mdx
@@ -68,7 +68,7 @@ void map_page(uint32_t *table1, uint32_t vaddr, paddr_t paddr, uint32_t flags) {
 
 2段目のページテーブルを用意して、2段目の設定したいページテーブルエントリへマップ先の物理ページ番号とフラグを設定するだけです。
 
-`paddr / PAGE_SIZE`と`PAGE_SIZE`で割っているのは、エントリに設定するのはページ番号ではなく物理ページ番号だからです。
+`paddr / PAGE_SIZE`と`PAGE_SIZE`で割っているのは、エントリに設定するのは物理アドレスではなく物理ページ番号だからです。
 
 ## カーネルページのマッピング
 


### PR DESCRIPTION
(この修正があっているか自信があまりないのですが)paddrの意味がページ番号となっているのを物理アドレスに直しました.
