### PR TITLE
Feedback from @rhysd

### DIFF
--- a/common.c
+++ b/common.c
@@ -41,7 +41,8 @@ void printf(const char *fmt, ...) {
     va_start(vargs, fmt);
     while (*fmt) {
         if (*fmt == '%') {
-            fmt++;
+            if (*(fmt + 1))
+                fmt++;
             switch (*fmt) {
                 case '\0':
                 case '%':

--- a/common.c
+++ b/common.c
@@ -41,10 +41,11 @@ void printf(const char *fmt, ...) {
     va_start(vargs, fmt);
     while (*fmt) {
         if (*fmt == '%') {
-            if (*(fmt + 1))
-                fmt++;
+            fmt++;
             switch (*fmt) {
                 case '\0':
+                    putchar('%');
+                    goto end;
                 case '%':
                     putchar('%');
                     break;
@@ -90,5 +91,6 @@ void printf(const char *fmt, ...) {
         fmt++;
     }
 
+end:
     va_end(vargs);
 }

--- a/disk/hello.txt
+++ b/disk/hello.txt
@@ -1,1 +1,1 @@
-Can you see me? Ah, there you are! You've unlocked the achivement "Virtio Newbie!"
+Can you see me? Ah, there you are! You've unlocked the achievement "Virtio Newbie!"

--- a/kernel.c
+++ b/kernel.c
@@ -65,10 +65,6 @@ struct virtio_blk_req *blk_req;
 paddr_t blk_req_paddr;
 unsigned blk_capacity;
 
-uint8_t virtio_reg_read8(unsigned offset) {
-    return *((volatile uint8_t *) (VIRTIO_BLK_PADDR + offset));
-}
-
 uint32_t virtio_reg_read32(unsigned offset) {
     return *((volatile uint32_t *) (VIRTIO_BLK_PADDR + offset));
 }

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ $OBJCOPY -Ibinary -Oelf32-littleriscv shell.bin shell.bin.o
 $CC $CFLAGS -Wl,-Tkernel.ld -Wl,-Map=kernel.map -o kernel.elf \
     kernel.c common.c shell.bin.o
 
-tar cf disk.tar --format=ustar -C disk .
+(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \

--- a/website/contents/ja/06-hello-world.mdx
+++ b/website/contents/ja/06-hello-world.mdx
@@ -147,7 +147,8 @@ void printf(const char *fmt, ...) {
 
     while (*fmt) {
         if (*fmt == '%') {
-            fmt++;
+            if (*(fmt + 1))
+                fmt++;
             switch (*fmt) {
                 case '\0':
                 case '%':

--- a/website/contents/ja/06-hello-world.mdx
+++ b/website/contents/ja/06-hello-world.mdx
@@ -147,10 +147,11 @@ void printf(const char *fmt, ...) {
 
     while (*fmt) {
         if (*fmt == '%') {
-            if (*(fmt + 1))
-                fmt++;
+            fmt++;
             switch (*fmt) {
                 case '\0':
+                    putchar('%');
+                    goto end;
                 case '%':
                     putchar('%');
                     break;
@@ -196,6 +197,7 @@ void printf(const char *fmt, ...) {
         fmt++;
     }
 
+end:
     va_end(vargs);
 }
 ```

--- a/website/contents/ja/14-user-mode.mdx
+++ b/website/contents/ja/14-user-mode.mdx
@@ -24,7 +24,7 @@ extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
 
 ```c:kernel.c {1-3,5,11,20-26}
 __attribute__((naked)) void user_entry(void) {
-    PANIC("not yet implemeneted"); // 後で実装する
+    PANIC("not yet implemented"); // 後で実装する
 }
 
 struct process *create_process(const void *image, size_t image_size) {

--- a/website/contents/ja/15-system-call.mdx
+++ b/website/contents/ja/15-system-call.mdx
@@ -48,7 +48,7 @@ void putchar(char ch) {
 
 次に、`ecall` 命令を実行したときに呼び出される例外ハンドラを更新します。
 
-```c:kernel.c {4-6,11}
+```c:kernel.c {5-7,12}
 void handle_trap(struct trap_frame *f) {
     uint32_t scause = READ_CSR(scause);
     uint32_t stval = READ_CSR(stval);
@@ -206,7 +206,7 @@ Hello world from shell!
 #define SYS_EXIT    3
 ```
 
-```c:user.c {1-2}
+```c:user.c {2-3}
 __attribute__((noreturn)) void exit(void) {
     syscall(SYS_EXIT, 0, 0, 0);
     for (;;); // 念のため

--- a/website/contents/ja/16-virtio-blk.mdx
+++ b/website/contents/ja/16-virtio-blk.mdx
@@ -121,10 +121,6 @@ struct virtio_blk_req {
 続いてvirtioデバイスのMMIO上のレジスタを操作するための便利な関数を `kernel.c` に追加します。
 
 ```c:kernel.c
-uint8_t virtio_reg_read8(unsigned offset) {
-    return *((volatile uint8_t *) (VIRTIO_BLK_PADDR + offset));
-}
-
 uint32_t virtio_reg_read32(unsigned offset) {
     return *((volatile uint32_t *) (VIRTIO_BLK_PADDR + offset));
 }

--- a/website/contents/ja/16-virtio-blk.mdx
+++ b/website/contents/ja/16-virtio-blk.mdx
@@ -43,7 +43,7 @@ $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
 新たに追加したオプションは次の通りです:
 
 - `-drive id=drive0`: ディスク`drive0`を定義。`lorem.txt`をディスクイメージとしてQEMUに渡す。ディスクイメージの形式は`raw` (ファイルの内容をそのままディスクデータとして扱う)。
-- `-device virtio-blk-device`: virtio-blkデバイスを追加する。ディスク`drive0`に接続する。`bus=virtio-mmio-bus.0`を指定することで、MMIO領域にデバイスをマップする。
+- `-device virtio-blk-device`: virtio-blkデバイスを追加する。ディスク`drive0`に接続する。`bus=virtio-mmio-bus.0`を指定することで、MMIO (Memory Mapped I/O) 領域にデバイスをマップする。
 
 ## 雑多な定義
 

--- a/website/contents/ja/17-file-system.mdx
+++ b/website/contents/ja/17-file-system.mdx
@@ -429,7 +429,7 @@ __attribute__((naked)) void user_entry(void) {
 $ ./run.sh
 
 > readfile
-Can you see me? Ah, there you are! You've unlocked the achivement "Virtio Newbie!"
+Can you see me? Ah, there you are! You've unlocked the achievement "Virtio Newbie!"
 ```
 
 ファイルの書き込みも試してみましょう。書き込みが成功すると、次のように書き込んだバイト数が表示されます。

--- a/website/contents/ja/17-file-system.mdx
+++ b/website/contents/ja/17-file-system.mdx
@@ -27,7 +27,7 @@ $ vim disk/meow.txt
 ビルドスクリプトにtarファイルの作成コマンドを追加し、それをディスクイメージとしてQEMUに渡すようにします。
 
 ```bash:run.sh {1,5}
-tar cf disk.tar --format=ustar -C disk .
+(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \
@@ -40,7 +40,6 @@ $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
 
 - `cf`: tarファイルを作成する
 - `--format=ustar`: ustar形式のtarファイルを作成する
-- `-C disk .`: `disk` ディレクトリ中のファイルを含める
 
 ## tarファイルの構造
 

--- a/website/contents/ja/17-file-system.mdx
+++ b/website/contents/ja/17-file-system.mdx
@@ -41,6 +41,8 @@ $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
 - `cf`: tarファイルを作成する
 - `--format=ustar`: ustar形式のtarファイルを作成する
 
+なお、tarコマンドの行が丸括弧 `(...)` で囲われているのは、囲われたコマンドを独立したシェルで実行する **サブシェル** という機能です。これを使うことで、`cd` コマンドでのディレクトリ移動が括弧外に影響しないようにできます。
+
 ## tarファイルの構造
 
 tarファイルは、次のような構造をしています。


### PR DESCRIPTION
「1000行で作るオペレーティングシステム」楽しませていただきました．ありがとうございました．

やっていて何点か気になった点があったのでフィードバックさせてください．

- 細かいですが `printf` のフォーマット文字列の最後が `%` だった時に OOB するバグがあります (6e59b11)
- タイポ修正 (13d3d74)
- いくつかコードスニペットの中でハイライトする行番号を間違えている箇所がありました (ce9de35)
- MMIO が何の略か（自明と言われればそうかもしれませんが…）明らかでなかったので明記しました (2d51e99)
- テキストにある `tar` コマンドだとカレントディレクトリ `.` がエントリの最初に来てしまってテキスト通りになりませんでした（GNU tar と BSD tar の両方で確認）．これを避けてテキスト通りにするには，ディレクトリ `.` を tar アーカイブに加える代わりに各ファイル `*.txt` を直接加える必要がありました (c07d946)