### PR TITLE
fix strcmp

### DIFF
--- a/common.c
+++ b/common.c
@@ -31,7 +31,7 @@ int strcmp(const char *s1, const char *s2) {
         s2++;
     }
 
-    return *s1 - *s2;
+    return *(unsigned char *)s1 - *(unsigned char *)s2;
 }
 
 void putchar(char ch);


### PR DESCRIPTION
## 概要

man strcmpのRETURN VALUEに以下のように記載されています

> The strcmp() and strncmp() functions return an integer greater than, equal to, or less than 0, according as the string s1 is greater than, equal to, or less than the string s2.  The comparison is done using unsigned characters, so that ‘\200’ is greater than ‘\0’.

比較はunsignedで行うのでその修正をしました。

分かりやすさのために元のソースが意図的でしたら申し訳ないです。不採用にしてください。

## 修正前

```c
char str1[2] = {100, 0};
char str2[2] = {200, 0};

int result = 0;
result = strcmp(str1, str2)

// 結果：156
```

## 修正後

```c
char str1[2] = {100, 0};
char str2[2] = {200, 0};

int result = 0;
result = strcmp(str1, str2)

// 結果：-100
```
