### PR TITLE
ユーザアプリケーションのスタックアライメント問題の修正

### DIFF
--- a/user.ld
+++ b/user.ld
@@ -19,7 +19,7 @@ SECTIONS {
     .bss : ALIGN(4) {
         *(.bss .bss.* .sbss .sbss.*);
 
-        . = ALIGN(4);
+        . = ALIGN(16);
         . += 64 * 1024; /* 64KB */
         __stack_top = .;
 

--- a/user.ld
+++ b/user.ld
@@ -19,7 +19,7 @@ SECTIONS {
     .bss : ALIGN(4) {
         *(.bss .bss.* .sbss .sbss.*);
 
-        . = ALIGN(16);
+        . = ALIGN(16); /* https://github.com/nuta/operating-system-in-1000-lines/pull/23 */
         . += 64 * 1024; /* 64KB */
         __stack_top = .;
 

--- a/website/contents/ja/13-application.mdx
+++ b/website/contents/ja/13-application.mdx
@@ -32,7 +32,7 @@ SECTIONS {
     .bss : ALIGN(4) {
         *(.bss .bss.* .sbss .sbss.*);
 
-        . = ALIGN(16);
+        . = ALIGN(16); /* https://github.com/nuta/operating-system-in-1000-lines/pull/23 */
         . += 64 * 1024; /* 64KB */
         __stack_top = .;
 

--- a/website/contents/ja/13-application.mdx
+++ b/website/contents/ja/13-application.mdx
@@ -32,7 +32,7 @@ SECTIONS {
     .bss : ALIGN(4) {
         *(.bss .bss.* .sbss .sbss.*);
 
-        . = ALIGN(4);
+        . = ALIGN(16);
         . += 64 * 1024; /* 64KB */
         __stack_top = .;
 


### PR DESCRIPTION
https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf

> In the standard RISC-V calling convention,
> the stack grows downward and the stack pointer is
> always kept 16-byte aligned.

RISC-Vの呼び出し規約では、関数呼び出しをする際はSPが16byteアライメントされている必要があります。
user.ldを見る限りでは4Byteアライメントになっております。

別の方がD言語で書かれている際に最適化オプションをつけると、動かなくなるという不具合が発生しました。
https://github.com/kubo39/ldc-os-in-1000-lines/issues/3

これの原因は、ローカル変数の配列の参照をする際に、スタックが16バイトアライメントされている事を期待して、cmdlineのi番目のアドレス生成をcmdlineのベースアドレスとiのOR演算で行っている為でした。

このような問題はこちらのプロジェクトでも発生しうると思いますので、こちらにもPRさせていただきます。
