### PR TITLE
tarへ書き込む8進数表現のファイルサイズの修正

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -200,11 +200,10 @@ void fs_flush(void) {
         header->type = '0';
 
         int filesz = file->size;
-        int i = 0;
-        do {
-            header->size[i++] = (filesz % 8) + '0';
+        for (int i = sizeof(header->size); i > 0; i--) {
+            header->size[i - 1] = (filesz % 8) + '0';
             filesz /= 8;
-        } while (filesz > 0);
+        }
 
         int checksum = ' ' * sizeof(header->checksum);
         for (unsigned i = 0; i < sizeof(struct tar_header); i++)

--- a/website/contents/ja/17-file-system.mdx
+++ b/website/contents/ja/17-file-system.mdx
@@ -199,11 +199,10 @@ void fs_flush(void) {
 
         // ファイルサイズを8進数文字列に変換
         int filesz = file->size;
-        int i = 0;
-        do {
-            header->size[i++] = (filesz % 8) + '0';
+        for (int i = sizeof(header->size); i > 0; i--) {
+            header->size[i - 1] = (filesz % 8) + '0';
             filesz /= 8;
-        } while (filesz > 0);
+        }
 
         // チェックサムを計算
         int checksum = ' ' * sizeof(header->checksum);


### PR DESCRIPTION
OSについてとても勉強になる資料をありがとうございます!エナガ本と併せて楽しんで取り組ませていただきました。

## 変更点
- tarヘッダのファイルサイズは`header->size`の末尾に8進数表現の1桁目が入り、インデックスの0に向かって2桁目,3桁目,...となっていくと思いますが、現在の実装が逆順になっていたため修正をさせていただきました。
- また、tarヘッダのファイルサイズは数字の文字表現を要求するため、0埋めを数字の`0`ではなく文字の`'0'`で埋めるようにしました。

## `writefile`コマンド実行後の`hello.txt`のファイルサイズ
`writefile("./hello.txt", "Hello from shell!\n", 19);`のように書き込んでいるのでファイルサイズは19と表示されるのが期待した結果かなと思いました。

### 修正前
```sh
$ tar -tvf disk.tar
-rw-r--r--  0 0      0          26  1  1  1970 ./hello.txt
-rw-r--r--  0 0      0           6  1  1  1970 ./meow.txt
```

### 修正後
```sh
$ tar -tvf disk.tar                
-rw-r--r--  0 0      0          19  1  1  1970 ./hello.txt
-rw-r--r--  0 0      0           6  1  1  1970 ./meow.txt
```