### PR TITLE
Bug fix: Information leak in create_process

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -438,7 +438,9 @@ struct process *create_process(const void *image, size_t image_size) {
     // User pages.
     for (uint32_t off = 0; off < image_size; off += PAGE_SIZE) {
         paddr_t page = alloc_pages(1);
-        memcpy((void *) page, image + off, PAGE_SIZE);
+        size_t remain = image_size - off;
+        size_t size = PAGE_SIZE <= remain ? PAGE_SIZE : remain;
+        memcpy((void *) page, image + off, size);
         map_page(page_table, USER_BASE + off, page,
                  PAGE_U | PAGE_R | PAGE_W | PAGE_X);
     }

--- a/kernel.c
+++ b/kernel.c
@@ -438,9 +438,9 @@ struct process *create_process(const void *image, size_t image_size) {
     // User pages.
     for (uint32_t off = 0; off < image_size; off += PAGE_SIZE) {
         paddr_t page = alloc_pages(1);
-        size_t remain = image_size - off;
-        size_t size = PAGE_SIZE <= remain ? PAGE_SIZE : remain;
-        memcpy((void *) page, image + off, size);
+        size_t remaining = image_size - off;
+        size_t copy_size = PAGE_SIZE <= remaining ? PAGE_SIZE : remaining;
+        memcpy((void *) page, image + off, copy_size);
         map_page(page_table, USER_BASE + off, page,
                  PAGE_U | PAGE_R | PAGE_W | PAGE_X);
     }


### PR DESCRIPTION
`create_process`の以下の部分についての修正です。
```c
memcpy((void *) page, image + off, PAGE_SIZE);
```
image_sizeがPAGE_SIZEの倍数でない場合、カーネル内の情報(image + image_size以降の情報)がユーザーランドのスタックの後ろにコピーされるため、ユーザーランドからカーネル内の情報を読むことが出来てしまいます。

セキュリティを考えるなら修正すべきですが、自作OSでそこまで考えるべきかは微妙なので、実装を簡単に保ちたいという意図であれば無視してください。(とはいえ、簡単には気づかないかつ現実にありそうなバグなので話のネタにはなると思います)