### PR TITLE
06-libc.md: Memory Operations code snippets swap

### DIFF
--- a/website/en/06-libc.md
+++ b/website/en/06-libc.md
@@ -65,23 +65,23 @@ Next, we implement the following memory operation functions.
 The `memcpy` function copies `n` bytes from `src` to `dst`:
 
 ```c:common.c
-void *memset(void *buf, char c, size_t n) {
-    uint8_t *p = (uint8_t *) buf;
-    while (n--)
-        *p++ = c;
-    return buf;
-}
-```
-
-The `memset` function fills the first `n` bytes of `buf` with `c`. This function has already been implemented in Chapter 4 for initializing the bss section. Let's move it from `kernel.c` to `common.c`:
-
-```c:common.c
 void *memcpy(void *dst, const void *src, size_t n) {
     uint8_t *d = (uint8_t *) dst;
     const uint8_t *s = (const uint8_t *) src;
     while (n--)
         *d++ = *s++;
     return dst;
+}
+```
+
+The `memset` function fills the first `n` bytes of `buf` with `c`. This function has already been implemented in Chapter 4 for initializing the bss section. Let's move it from `kernel.c` to `common.c`:
+
+```c:common.c
+void *memset(void *buf, char c, size_t n) {
+    uint8_t *p = (uint8_t *) buf;
+    while (n--)
+        *p++ = c;
+    return buf;
 }
 ```
 

--- a/website/ja/06-libc.md
+++ b/website/ja/06-libc.md
@@ -65,23 +65,23 @@ void printf(const char *fmt, ...);
 `memcpy`関数は`src`から`n`バイト分を`dst`にコピーします。
 
 ```c:common.c
-void *memset(void *buf, char c, size_t n) {
-    uint8_t *p = (uint8_t *) buf;
-    while (n--)
-        *p++ = c;
-    return buf;
-}
-```
-
-`memset`関数は`buf`の先頭から`n`バイト分を`c`で埋めます。この関数は、bssセクションの初期化のために4章で実装済みです。`kernel.c`から`common.c`に移動させましょう。
-
-```c:common.c
 void *memcpy(void *dst, const void *src, size_t n) {
     uint8_t *d = (uint8_t *) dst;
     const uint8_t *s = (const uint8_t *) src;
     while (n--)
         *d++ = *s++;
     return dst;
+}
+```
+
+`memset`関数は`buf`の先頭から`n`バイト分を`c`で埋めます。この関数は、bssセクションの初期化のために4章で実装済みです。`kernel.c`から`common.c`に移動させましょう。
+
+```c:common.c
+void *memset(void *buf, char c, size_t n) {
+    uint8_t *p = (uint8_t *) buf;
+    while (n--)
+        *p++ = c;
+    return buf;
 }
 ```
 


### PR DESCRIPTION
Swap the `memcpy` and `memset` code snippets in `06-libc.md` (both en and ja versions) to align with the surrounding text.