### PR TITLE
fix: correct typo from stacj to stack

### DIFF
--- a/website/en/09-memory-allocation.md
+++ b/website/en/09-memory-allocation.md
@@ -23,7 +23,7 @@ Before implementing a memory allocator, let's define the memory regions to be ma
 }
 ```
 
-This adds two new symbols: `__free_ram` and `__free_ram_end`. This defines a memory are after the stacj space . The size of the space (64MB) is an arbitrary value and `. = ALIGN(4096)` ensures that it's aligned to a 4KB boundary.
+This adds two new symbols: `__free_ram` and `__free_ram_end`. This defines a memory are after the stack space . The size of the space (64MB) is an arbitrary value and `. = ALIGN(4096)` ensures that it's aligned to a 4KB boundary.
 
 By defining this in the linker script instead of hardcoding addresses, the linker can determine the position to avoid overlapping with the kernel's static data.
 


### PR DESCRIPTION
Corrected a spelling error in reference to "stack."