### PR TITLE
Update 04-boot.md with proper kernel.ld path

### DIFF
--- a/website/en/04-boot.md
+++ b/website/en/04-boot.md
@@ -240,7 +240,7 @@ CC=/opt/homebrew/opt/llvm/bin/clang  # Ubuntu users: use CC=clang
 CFLAGS="-std=c11 -O2 -g3 -Wall -Wextra --target=riscv32 -ffreestanding -nostdlib"
 
 # new: Build the kernel
-$CC $CFLAGS -Wl,-Tkernel.ld -Wl,-Map=kernel.map -o kernel.elf \
+$CC $CFLAGS -Wl,-kernel.ld -Wl,-Map=kernel.map -o kernel.elf \
     kernel.c
 
 # Start QEMU


### PR DESCRIPTION
```
clang -std=c11 -O2 -g3 -Wall -Wextra --target=riscv32 -ffreestanding -nostdlib -Wl,Tkernel.ld -Wl,-Map=kernel.map -o kernel.elf kernel.c
ld.lld: error: cannot open Tkernel.ld: No such file or directory
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```