### PR TITLE
Adjusting epub

### DIFF
--- a/epub/stylesheet.css
+++ b/epub/stylesheet.css
@@ -1,0 +1,3 @@
+pre, code {
+  white-space: pre-wrap !important;
+}

--- a/make-epub.sh
+++ b/make-epub.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 cd website/en
 pandoc \
-  -o ../../"Writing an OS in 1,000 Lines, v0.1-alpha.epub" \
+  -f gfm+alerts \
+  -o ../../"Writing an OS in 1,000 Lines, v0.1.1-alpha.epub" \
   ../../epub/title.txt \
   {index.md,0*.md,1*.md} \
   --css=../../epub/stylesheet.css \


### PR DESCRIPTION
Parsing as Github-Flavored Markdown -
code blocks and tip sections work together now.
This made the book more readable, and added around 25% more pages, newly legible.
This will hiccup on the frontmatter, removed separately in #51 .

The stylesheet enables text wrapping for code.
Previously, the "Lorem ipsum" text in the "Disk I/O" chapter overflowed multiple pages to the right, with the same vertical position on the page.
(One line tall, several pages wide.)
This fixes it in Bluefire, and wide code blocks on Books.app.

I pulled this from a StackOverflow answer:
https://stackoverflow.com/questions/20788464/pandoc-doesnt-text-wrap-code-blocks-when-converting-to-pdf