### PR TITLE
fixing parameter typo in 'en' website tutorial

### DIFF
--- a/website/en/12-application.md
+++ b/website/en/12-application.md
@@ -60,7 +60,7 @@ __attribute__((noreturn)) void exit(void) {
     for (;;);
 }
 
-void putchar(char c) {
+void putchar(char ch) {
     /* TODO */
 }
 


### PR DESCRIPTION
Hi, awesome tutorial!