### PR TITLE
Eliminate ./ from paths in tar (filesystem)

### DIFF
--- a/website/en/16-file-system.md
+++ b/website/en/16-file-system.md
@@ -25,7 +25,7 @@ $ vim disk/meow.txt
 Add a command to the build script to create a tar file and pass it as a disk image to QEMU:
 
 ```bash [run.sh] {1,5}
-(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)                          # new
+(cd disk && tar cf ../disk.tar --format=ustar *.txt)                          # new
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \

--- a/website/ja/16-file-system.md
+++ b/website/ja/16-file-system.md
@@ -29,7 +29,7 @@ $ vim disk/meow.txt
 ビルドスクリプトにtarファイルの作成コマンドを追加し、それをディスクイメージとしてQEMUに渡すようにします。
 
 ```bash [run.sh] {1,5}
-(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)
+(cd disk && tar cf ../disk.tar --format=ustar *.txt)
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \

--- a/website/ko/16-file-system.md
+++ b/website/ko/16-file-system.md
@@ -29,7 +29,7 @@ $ vim disk/meow.txt
 Add a command to the build script to create a tar file and pass it as a disk image to QEMU:
 
 ```bash [run.sh] {1,5}
-(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)                          # new
+(cd disk && tar cf ../disk.tar --format=ustar *.txt)                          # new
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \

--- a/website/zh/16-file-system.md
+++ b/website/zh/16-file-system.md
@@ -29,7 +29,7 @@ $ vim disk/meow.txt
 在构建脚本中添加一条命令来创建 tar 文件并将其作为磁盘镜像传递给 QEMU：
 
 ```bash [run.sh] {1,5}
-(cd disk && tar cf ../disk.tar --format=ustar ./*.txt)                          # new
+(cd disk && tar cf ../disk.tar --format=ustar *.txt)                          # new
 
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
     -d unimp,guest_errors,int,cpu_reset -D qemu.log \


### PR DESCRIPTION
When creating the tar file for the filesystem, it should not have ./ before the filenames. If it does, then the readfile shell command implemented in shell.c doesn't work, because it expects the filename without the ./

run.sh in github is like this, so it only needs to be updated in the website.

Thanks a lot for the book, it is really nice!