### PR TITLE
Fix line highlighting

### DIFF
--- a/website/en/10-process.md
+++ b/website/en/10-process.md
@@ -302,7 +302,7 @@ Since the stack pointer extends towards lower addresses, we set the address at t
 
 The modifications to the exception handler are as follows:
 
-```c [kernel.c] {3-4,38-44}
+```c [kernel.c] {3-4,38,42-44}
 void kernel_entry(void) {
     __asm__ __volatile__(
         // Retrieve the kernel stack of the running process from sscratch.

--- a/website/ko/10-process.md
+++ b/website/ko/10-process.md
@@ -319,7 +319,7 @@ void yield(void) {
 
 다음으로 예외 핸들러(`kernel_entry`)에서 수정합니다.
 
-```c [kernel.c] {3-4,38-44}
+```c [kernel.c] {3-4,38,42-44}
 void kernel_entry(void) {
     __asm__ __volatile__(
         // Retrieve the kernel stack of the running process from sscratch.

--- a/website/zh/10-process.md
+++ b/website/zh/10-process.md
@@ -305,7 +305,7 @@ void yield(void) {
 
 对异常处理程序的修改如下：
 
-```c [kernel.c] {3-4,38-44}
+```c [kernel.c] {3-4,38,42-44}
 void kernel_entry(void) {
     __asm__ __volatile__(
         // 从sscratch中获取运行进程的内核栈


### PR DESCRIPTION
Hello! As I was going through section 10 (Process) I noticed [these lines](https://github.com/nuta/operating-system-in-1000-lines/blob/33bf69c1841c759e0a102b5a51364dbff919f987/website/en/10-process.md?plain=1#L344-L345) were highlighted even though they hadn't changed. [They were added in section 8 (Exception)](https://github.com/nuta/operating-system-in-1000-lines/blob/33bf69c1841c759e0a102b5a51364dbff919f987/website/en/08-exception.md?plain=1#L70-L71). 

This change removes the highlighting for those lines but not the comment above them which is a new addition.

Sorry if I'm missing something here, and thanks for writing this!