### PR TITLE
[tw] Update comment to reflect 2nd level page table creation

### DIFF
--- a/website/tw/11-page-table.md
+++ b/website/tw/11-page-table.md
@@ -67,7 +67,7 @@ void map_page(uint32_t *table1, uint32_t vaddr, paddr_t paddr, uint32_t flags) {
 
     uint32_t vpn1 = (vaddr >> 22) & 0x3ff;
     if ((table1[vpn1] & PAGE_V) == 0) {
-        // Create the 1st level page table if it doesn't exist.
+        // Create the 2nd level page table if it doesn't exist.
         uint32_t pt_paddr = alloc_pages(1);
         table1[vpn1] = ((pt_paddr / PAGE_SIZE) << 10) | PAGE_V;
     }


### PR DESCRIPTION
The 1st page table is already allocated in create_process(). In map_page(), when table1[vpn1] is invalid we actually allocate and set a 2nd page table.