### PR TITLE
Add missing content in Korean translation

### DIFF
--- a/website/ko/01-setting-up-development-environment.md
+++ b/website/ko/01-setting-up-development-environment.md
@@ -17,6 +17,14 @@ title: 환경설정
 brew install llvm lld qemu
 ```
 
+또한, LLVM 유틸리티를 사용할 수 있도록 `PATH`를 설정합니다.
+
+```
+$ export PATH="$PATH:$(brew --prefix)/opt/llvm/bin"
+$ which llvm-objcopy
+/opt/homebrew/opt/llvm/bin/llvm-objcopy
+```
+
 ### Ubuntu
 
 1. apt 패키지 관리자 업데이트 후, 필요한 패키지들을 설치합니다.


### PR DESCRIPTION
This resolves #122.

The issue pointed out that commands for the `PATH` variable are missing from chapter 1, and it seems to be referring to the Korean version.

This PR updates the Korean version to match the English and Japanese versions:
https://github.com/nuta/operating-system-in-1000-lines/blob/5f443972050be3a34de2e01d3c0ce4e12dc8171e/website/ja/01-setting-up-development-environment.md?plain=1#L19-L25
Updates to other languages would be better handled by other contributors.